### PR TITLE
set tar input file to standard input in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ kjv: kjv.sh kjv.awk kjv.tsv
 	echo 'exit 0' >> $@
 
 	echo '#EOF' >> $@
-	tar cz kjv.awk kjv.tsv >> $@
+	tar czf - kjv.awk kjv.tsv >> $@
 
 	chmod +x $@
 


### PR DESCRIPTION
Tested in Manjaro Linux & FreeBSD. When paired with the last commit, it fixes runtime errors in BSD.