### PR TITLE
Kjv new options

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ Read the Word of God from your terminal
     Flags:
       -A num  show num verses of context after matching verses
       -B num  show num verses of context before matching verses
+      -W num  enable line wrap to a specific width
       -C      show matching verses in context of the chapter
       -e      highlighting of chapters and verse numbers
               (default when output is a TTY)
       -p      output to less with chapter grouping, spacing, indentation,
               and line wrapping
               (default when output is a TTY)
+      -b      have a blank line after each verse
+      -i      remove all highlighting
       -l      list books
       -h      show help
 

--- a/src/kjv_config.h
+++ b/src/kjv_config.h
@@ -11,4 +11,7 @@ typedef struct {
     int context_before;
     int context_after;
     bool context_chapter;
+    bool blank_line_after_verse;
+    bool change_line_width;
 } kjv_config;
+

--- a/src/kjv_render.c
+++ b/src/kjv_render.c
@@ -9,7 +9,7 @@
 #include "kjv_match.h"
 #include "kjv_render.h"
 
-#define ESC_BOLD "\033[1m"
+#define ESC_BOLD "\033[1;97m"
 #define ESC_UNDERLINE "\033[4m"
 #define ESC_RESET "\033[m"
 

--- a/src/kjv_render.c
+++ b/src/kjv_render.c
@@ -43,6 +43,10 @@ kjv_output_verse(const kjv_verse *verse, FILE *f, const kjv_config *config)
         word = strtok(NULL, " ");
     }
     fprintf(f, "\n");
+
+    if (config->blank_line_after_verse) {
+        fprintf(f, "\n");
+    }
 }
 
 static bool
@@ -145,3 +149,4 @@ kjv_render(const kjv_ref *ref, const kjv_config *config)
     kjv_output(ref, stdout, config);
     return 0;
 }
+


### PR DESCRIPTION
Adding three new options:

- `-W num`: to set the width of the line.
- `-i`: disable the highlighting (if you want to copy the text in less)
- `-b`: add a blank line after all versus

Example:
```
kjv -b -i -W 50 matthew:7:1-5
```
In less press `|` then `$` then run `xclip -selection clipboard`. I didn't find an easier way to copy or print the text without using less (If you have another method without using less or xclip, say so. Thank you)

Output:
```
Matthew

7:1	Judge not, that ye be not judged.

7:2	For with what judgment ye judge, ye
	shall be judged: and with what measure
	ye mete, it shall be measured to you
	again.

7:3	And why beholdest thou the mote that is
	in thy brother's eye, but considerest
	not the beam that is in thine own eye?

7:4	Or how wilt thou say to thy brother, Let
	me pull out the mote out of thine eye;
	and, behold, a beam is in thine own eye?

7:5	Thou hypocrite, first cast out the beam
	out of thine own eye; and then shalt
	thou see clearly to cast out the mote
	out of thy brother's eye.
```
